### PR TITLE
Update issues with valet on arch linux

### DIFF
--- a/cli/Valet/Configuration.php
+++ b/cli/Valet/Configuration.php
@@ -90,6 +90,10 @@ class Configuration
      */
     public function get(string $key, $default = null)
     {
+        if (!$this->files->exists($this->path())) {
+            return $default;
+        }
+
         $config = $this->read();
 
         return array_key_exists($key, $config) ? $config[$key] : $default;

--- a/cli/Valet/Contracts/PackageManager.php
+++ b/cli/Valet/Contracts/PackageManager.php
@@ -48,4 +48,10 @@ interface PackageManager
      * Get package name by service
      */
     public function packageName(string $name): string;
+
+    /**
+     * This function will determine whether a package manager supports versioned
+     * packages e.g php78-cli, php-78-gd etc
+     */
+    public function supportsVersionedPackages(): bool;
 }

--- a/cli/Valet/Filesystem.php
+++ b/cli/Valet/Filesystem.php
@@ -133,6 +133,10 @@ class Filesystem
      */
     public function put(string $path, string $contents, ?string $owner = null): string
     {
+        if (!$this->exists($path)) {
+            $this->ensureDirExists(dirname($path), user());
+        }
+
         $status = file_put_contents($path, $contents);
 
         if ($owner) {

--- a/cli/Valet/Nginx.php
+++ b/cli/Valet/Nginx.php
@@ -180,7 +180,7 @@ class Nginx
      */
     private function rewriteSecureNginxFiles(): void
     {
-        $domain = $this->configuration->get('domain');
+        $domain = $this->configuration->get('domain', 'test');
 
         $this->siteSecure->reSecureForNewDomain($domain, $domain);
     }

--- a/cli/Valet/Nginx.php
+++ b/cli/Valet/Nginx.php
@@ -136,6 +136,10 @@ class Nginx
      */
     public function configuredSites(): Collection
     {
+        if (!$this->files->exists(VALET_HOME_PATH . '/Nginx')) {
+            return collect([]);
+        }
+
         return collect($this->files->scandir(VALET_HOME_PATH . '/Nginx'))
             ->reject(function ($file) {
                 return str_starts_with($file, '.');

--- a/cli/Valet/PackageManagers/Apt.php
+++ b/cli/Valet/PackageManagers/Apt.php
@@ -143,4 +143,13 @@ class Apt implements PackageManager
         }
         throw new \InvalidArgumentException(\sprintf('Package not found by %s', $name));
     }
+
+    /**
+     * This function will determine whether a package manager supports versioned
+     * packages e.g php78-cli, php-78-gd etc
+     */
+    public function supportsVersionedPackages(): bool
+    {
+        return true;
+    }
 }

--- a/cli/Valet/PackageManagers/Dnf.php
+++ b/cli/Valet/PackageManagers/Dnf.php
@@ -138,4 +138,13 @@ class Dnf implements PackageManager
         }
         throw new \InvalidArgumentException(\sprintf('Package not found by %s', $name));
     }
+
+    /**
+     * This function will determine whether a package manager supports versioned
+     * packages e.g php78-cli, php-78-gd etc
+     */
+    public function supportsVersionedPackages(): bool
+    {
+        return true;
+    }
 }

--- a/cli/Valet/PackageManagers/Eopkg.php
+++ b/cli/Valet/PackageManagers/Eopkg.php
@@ -142,4 +142,13 @@ class Eopkg implements PackageManager
         }
         throw new \InvalidArgumentException(\sprintf('Package not found by %s', $name));
     }
+
+    /**
+     * This function will determine whether a package manager supports versioned
+     * packages e.g php78-cli, php-78-gd etc
+     */
+    public function supportsVersionedPackages(): bool
+    {
+        return true;
+    }
 }

--- a/cli/Valet/PackageManagers/PackageKit.php
+++ b/cli/Valet/PackageManagers/PackageKit.php
@@ -149,4 +149,13 @@ class PackageKit implements PackageManager
         }
         throw new \InvalidArgumentException(\sprintf('Package not found by %s', $name));
     }
+
+    /**
+     * This function will determine whether a package manager supports versioned
+     * packages e.g php78-cli, php-78-gd etc
+     */
+    public function supportsVersionedPackages(): bool
+    {
+        return true;
+    }
 }

--- a/cli/Valet/PackageManagers/Pacman.php
+++ b/cli/Valet/PackageManagers/Pacman.php
@@ -147,4 +147,13 @@ class Pacman implements PackageManager
         }
         throw new \InvalidArgumentException(\sprintf('Package not found by %s', $name));
     }
+
+    /**
+     * This function will determine whether a package manager supports versioned
+     * packages e.g php78-cli, php-78-gd etc
+     */
+    public function supportsVersionedPackages(): bool
+    {
+        return false;
+    }
 }

--- a/cli/Valet/PackageManagers/Yum.php
+++ b/cli/Valet/PackageManagers/Yum.php
@@ -141,4 +141,13 @@ class Yum implements PackageManager
         }
         throw new \InvalidArgumentException(\sprintf('Package not found by %s', $name));
     }
+
+    /**
+     * This function will determine whether a package manager supports versioned
+     * packages e.g php78-cli, php-78-gd etc
+     */
+    public function supportsVersionedPackages(): bool
+    {
+        return false;
+    }
 }

--- a/cli/Valet/PhpFpm.php
+++ b/cli/Valet/PhpFpm.php
@@ -59,7 +59,7 @@ class PhpFpm
     {
         $version = $version ?: $this->getCurrentVersion();
         $version = $this->normalizePhpVersion($version);
-        if ($version === '') {
+        if ($version === '' && !($this->pm instanceof \Valet\PackageManagers\Pacman)) {
             return;
         }
 
@@ -400,6 +400,6 @@ class PhpFpm
      */
     private function getDefaultVersion(): string
     {
-        return $this->normalizePhpVersion(PHP_MAJOR_VERSION . '.' . PHP_MINOR_VERSION);
+        return $this->pm instanceof \Valet\PackageManagers\Pacman ? '' : $this->normalizePhpVersion(PHP_MAJOR_VERSION . '.' . PHP_MINOR_VERSION);
     }
 }

--- a/cli/Valet/PhpFpm.php
+++ b/cli/Valet/PhpFpm.php
@@ -59,7 +59,7 @@ class PhpFpm
     {
         $version = $version ?: $this->getCurrentVersion();
         $version = $this->normalizePhpVersion($version);
-        if ($version === '' && !($this->pm instanceof \Valet\PackageManagers\Pacman)) {
+        if ($version === '' && !$this->pm->supportsVersionedPackages()) {
             return;
         }
 
@@ -409,6 +409,6 @@ class PhpFpm
      */
     private function getDefaultVersion(): string
     {
-        return $this->pm instanceof \Valet\PackageManagers\Pacman ? '' : $this->normalizePhpVersion(PHP_MAJOR_VERSION . '.' . PHP_MINOR_VERSION);
+        return !$this->pm->supportsVersionedPackages() ? '' : $this->normalizePhpVersion(PHP_MAJOR_VERSION . '.' . PHP_MINOR_VERSION);
     }
 }

--- a/cli/Valet/PhpFpm.php
+++ b/cli/Valet/PhpFpm.php
@@ -297,9 +297,18 @@ class PhpFpm
     {
         $extArray = [];
         $extensionPrefix = $this->pm->getPhpExtensionPrefix($version);
-        foreach (self::COMMON_EXTENSIONS as $ext) {
-            $extArray[] = "{$extensionPrefix}{$ext}";
+
+        if (($this->pm instanceof \Valet\PackageManagers\Pacman)) {
+            foreach (self::COMMON_EXTENSIONS as $ext) {
+                $extArray[] = "{$extensionPrefix}{$ext}";
+            }
+
+        } else {
+            foreach (['gd'] as $ext) {
+                $extArray[] = "{$extensionPrefix}{$ext}";
+            }
         }
+
         $this->pm->ensureInstalled(implode(' ', $extArray));
     }
 

--- a/cli/Valet/SiteSecure.php
+++ b/cli/Valet/SiteSecure.php
@@ -194,6 +194,10 @@ class SiteSecure
      */
     private function trustCa(string $caPemPath): void
     {
+        if (!$this->files->exists($this->caCertificatePath)) {
+            $this->caCertificatePath = str_replace('local/', '', $this->caCertificatePath);
+        }
+
         $this->files->copy($caPemPath, sprintf('%s%s.crt', $this->caCertificatePath, $this->caCertificatePem));
         $this->cli->run('sudo update-ca-certificates');
 

--- a/cli/Valet/Valet.php
+++ b/cli/Valet/Valet.php
@@ -142,22 +142,27 @@ class Valet
             return;
         }
 
-        // Fetch FPM running process
-        $fpmVersions = $this->getRunningFpmVersions($oldHomePath);
+        $fpmVersions = [];
 
-        // Stop running fpm services
-        if (count($fpmVersions)) {
-            foreach ($fpmVersions as $fpmVersion) {
-                PhpFpmFacade::stop($fpmVersion);
+        if ($this->files->isDir($oldHomePath)) {
+            // Fetch FPM running process
+            $fpmVersions = $this->getRunningFpmVersions($oldHomePath);
+
+            // Stop running fpm services
+            if (count($fpmVersions)) {
+                foreach ($fpmVersions as $fpmVersion) {
+                    PhpFpmFacade::stop($fpmVersion);
+                }
             }
-        }
 
-        if ($this->files->exists($oldHomePath . '/valet.sock')) {
-            PhpFpmFacade::stop();
-        }
+            if ($this->files->exists($oldHomePath . '/valet.sock')) {
+                PhpFpmFacade::stop();
+            }
 
-        // Copy directory
-        $this->files->copyDirectory($oldHomePath, $newHomePath);
+            // Copy directory
+            $this->files->copyDirectory($oldHomePath, $newHomePath);
+
+        }
 
         // Replace $oldHomePath to $newHomePath in Certificates, Valet.conf file
         $this->updateNginxConfFiles();
@@ -216,6 +221,7 @@ class Valet
         $runningVersions = [];
 
         $files = $this->files->scandir($homePath);
+
         foreach ($files as $file) {
             preg_match('/valet(\d)(\d)\.sock/', $file, $matches);
             if (count($matches) >= 2) {

--- a/cli/Valet/Valet.php
+++ b/cli/Valet/Valet.php
@@ -199,7 +199,12 @@ class Valet
         $oldHomePath = OLD_VALET_HOME_PATH;
         $nginxPath = $newHomePath . '/Nginx';
 
-        $siteConfigs = $this->files->scandir($nginxPath);
+        $siteConfigs = [];
+
+        if ($this->files->isDir($nginxPath)) {
+            $siteConfigs = $this->files->scandir($nginxPath);
+        }
+
         foreach ($siteConfigs as $siteConfig) {
             $filePath = \sprintf('%s/%s', $nginxPath, $siteConfig);
             $content = $this->files->get($filePath);
@@ -207,7 +212,11 @@ class Valet
             $this->files->put($filePath, $content);
         }
 
-        $sitesAvailableConf = $this->files->get(Nginx::SITES_AVAILABLE_CONF);
+        $sitesAvailableConf = '';
+        if ($this->files->exists(Nginx::SITES_AVAILABLE_CONF)) {
+            $sitesAvailableConf = $this->files->get(Nginx::SITES_AVAILABLE_CONF);
+        }
+
         $sitesAvailableConf = str_replace($oldHomePath, $newHomePath, $sitesAvailableConf);
         $this->files->put(Nginx::SITES_AVAILABLE_CONF, $sitesAvailableConf);
 

--- a/cli/app.php
+++ b/cli/app.php
@@ -58,7 +58,7 @@ $app->command('install [--ignore-selinux]', function ($ignoreSELinux) {
     Configuration::install();
     Nginx::install();
     PhpFpm::install();
-    DnsMasq::install(Configuration::get('domain'));
+    DnsMasq::install(Configuration::get('domain', 'test'));
     Mailpit::install();
     ValetRedis::install();
     Nginx::restart();


### PR DESCRIPTION
- fixed issues with config migrations
- fixed ussues with pacman php extensions (all other extensions are installed by default except ```php-gd``` where valet tries to install every thing on arch which may cause issues)
- fixed default php version on arch. (pacman doesn't have any packages as ```php{version}-{ext}```).
- and many more