### PR TITLE
Adds support for `PHP 8.4`

### DIFF
--- a/cli/Valet/PhpFpm.php
+++ b/cli/Valet/PhpFpm.php
@@ -18,7 +18,7 @@ class PhpFpm
     protected Nginx $nginx;
 
     public const SUPPORTED_PHP_VERSIONS = [
-        '8.2', '8.3',
+        '8.2', '8.3', '8.4',
     ];
 
     public const ISOLATION_SUPPORTED_PHP_VERSIONS = [


### PR DESCRIPTION
PHP8.4 is knocking at the door and we should enable it to make our project compatible with the latest version.