### PR TITLE
Fixed deprecated valet http2 configs

### DIFF
--- a/cli/stubs/secure.isolated.valet.conf
+++ b/cli/stubs/secure.isolated.valet.conf
@@ -8,7 +8,8 @@ server {
 }
 
 server {
-    listen VALET_HTTPS_PORT ssl http2;
+    listen VALET_HTTPS_PORT ssl;
+    http2 on;
     listen 88;
     server_name VALET_SITE www.VALET_SITE *.VALET_SITE;
     root /;

--- a/cli/stubs/secure.proxy.valet.conf
+++ b/cli/stubs/secure.proxy.valet.conf
@@ -7,7 +7,8 @@ server {
 }
 
 server {
-    listen VALET_HTTPS_PORT ssl http2;
+    listen VALET_HTTPS_PORT ssl;
+    http2 on;
     listen 88;
     #listen VALET_LOOPBACK:443 ssl http2; # valet loopback
     server_name VALET_SITE www.VALET_SITE *.VALET_SITE;


### PR DESCRIPTION
this commit solves a deprecated nginx config from valet proxy configs

it replaces the deprecated
```conf
    listen VALET_HTTPS_PORT ssl http2;
```

with
```conf
    listen VALET_HTTPS_PORT ssl;
    http2 on;
```