### PR TITLE
Prevent valet from throwing an error during migration

### DIFF
--- a/cli/Valet/Valet.php
+++ b/cli/Valet/Valet.php
@@ -138,7 +138,7 @@ class Valet
         $oldHomePath = OLD_VALET_HOME_PATH;
 
         // Check if new config home already exists, then skip the process
-        if ($this->files->isDir($newHomePath)) {
+        if ($this->files->isDir($newHomePath) || !$this->files->exists($oldHomePath)) {
             return;
         }
 


### PR DESCRIPTION
This PR will fixes an issue where valet attempts to migrate configs from previous home folder ``` $HOME/.valet``` even if it doesn't exists. As a result, an error will be thrown in the terminal instead